### PR TITLE
chore: enable trusted publishing for npm and pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   release_pypi:
     name: Publish to PyPI
@@ -128,6 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -160,6 +161,5 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -54,10 +54,13 @@ const project = new JsiiProject({
   jestOptions: {
     configFilePath: 'jest.config.json',
   },
+  npmTrustedPublishing: true,
   npmAccess: NpmAccess.PUBLIC,
   publishToPypi: {
     distName: 'hallcor.pulumi-projen-project-types',
     module: 'hallcor.pulumi_projen_project_types',
+    trustedPublishing: true,
+    attestations: true,
   },
 
   // deps: [],                /* Runtime dependencies of this module. */


### PR DESCRIPTION
Fixes #