### PR TITLE
fix: use ESC outputs for GitHub app credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         uses: pulumi/esc-action@v1
         with:
           environment: github/public
-          export-environment-variables: false
+          export-environment-variables: PROJEN_APP_CLIENT_ID,PROJEN_APP_PRIVATE_KEY
           oidc-auth: true
           oidc-organization: corymhall
           oidc-requested-token-type: urn:pulumi:token-type:access_token:personal
@@ -73,8 +73,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ env.PROJEN_APP_CLIENT_ID }}
-          private-key: ${{ env.PROJEN_APP_PRIVATE_KEY }}
+          app-id: ${{ steps.esc.outputs.PROJEN_APP_CLIENT_ID }}
+          private-key: ${{ steps.esc.outputs.PROJEN_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: pulumi/esc-action@v1
         with:
           environment: github/public
-          export-environment-variables: false
+          export-environment-variables: PROJEN_APP_CLIENT_ID,PROJEN_APP_PRIVATE_KEY
           oidc-auth: true
           oidc-organization: corymhall
           oidc-requested-token-type: urn:pulumi:token-type:access_token:personal
@@ -58,8 +58,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ env.PROJEN_APP_CLIENT_ID }}
-          private-key: ${{ env.PROJEN_APP_PRIVATE_KEY }}
+          app-id: ${{ steps.esc.outputs.PROJEN_APP_CLIENT_ID }}
+          private-key: ${{ steps.esc.outputs.PROJEN_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -6,7 +6,11 @@ import {
   UpgradeDependenciesSchedule,
 } from 'projen/lib/javascript';
 import { addTypes } from './projenrc';
-import { GithubCredentials, PulumiEscSetup } from './src';
+import {
+  ExportEnvironmentVariables,
+  GithubCredentials,
+  PulumiEscSetup,
+} from './src';
 import { JsiiProject } from './src/internal/jsii-project';
 
 const project = new JsiiProject({
@@ -34,6 +38,10 @@ const project = new JsiiProject({
     pulumiEscSetup: PulumiEscSetup.fromOidcAuth({
       environment: 'github/public',
       organization: 'corymhall',
+      exportEnvironmentVariables: ExportEnvironmentVariables.fromMapping([
+        'PROJEN_APP_CLIENT_ID',
+        'PROJEN_APP_PRIVATE_KEY',
+      ]),
     }),
   }),
   githubOptions: {

--- a/API.md
+++ b/API.md
@@ -4760,7 +4760,7 @@ const githubCredentialsAppOptions: GithubCredentialsAppOptions = { ... }
 | <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsAppOptions.property.owner">owner</a></code> | <code>string</code> | The owner of the GitHub App installation. |
 | <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsAppOptions.property.permissions">permissions</a></code> | <code>projen.github.workflows.AppPermissions</code> | The permissions granted to the token. |
 | <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsAppOptions.property.privateKeySecret">privateKeySecret</a></code> | <code>string</code> | The secret containing the GitHub App private key. |
-| <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsAppOptions.property.pulumiEscSetup">pulumiEscSetup</a></code> | <code><a href="#@hallcor/pulumi-projen-project-types.PulumiEscSetup">PulumiEscSetup</a></code> | Optionally include setup steps to inject environment variables from Pulumi ESC. |
+| <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsAppOptions.property.pulumiEscSetup">pulumiEscSetup</a></code> | <code><a href="#@hallcor/pulumi-projen-project-types.PulumiEscSetup">PulumiEscSetup</a></code> | Optionally include setup steps and resolve app credentials from Pulumi ESC outputs. |
 | <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsAppOptions.property.repositories">repositories</a></code> | <code>string[]</code> | List of repositories to grant access to. |
 
 ---
@@ -4775,6 +4775,8 @@ public readonly clientIdSecret: string;
 - *Default:* PROJEN_APP_CLIENT_ID
 
 The name of the secret that contains the app client id.
+
+When `pulumiEscSetup` is provided, this value is used as the ESC output key.
 
 ---
 
@@ -4816,6 +4818,7 @@ public readonly privateKeySecret: string;
 The secret containing the GitHub App private key.
 
 Escaped newlines (\\n) will be automatically replaced with actual newlines.
+When `pulumiEscSetup` is provided, this value is used as the ESC output key.
 
 ---
 
@@ -4828,7 +4831,7 @@ public readonly pulumiEscSetup: PulumiEscSetup;
 - *Type:* <a href="#@hallcor/pulumi-projen-project-types.PulumiEscSetup">PulumiEscSetup</a>
 - *Default:* do not include pulumi esc setup
 
-Optionally include setup steps to inject environment variables from Pulumi ESC.
+Optionally include setup steps and resolve app credentials from Pulumi ESC outputs.
 
 ---
 
@@ -5454,7 +5457,7 @@ public readonly exportEnvironmentVariables: ExportEnvironmentVariables;
 Whether to export environment variables from ESC.
 
 Can also be an array of mapping strings to explicitly control which variables
-are exported (joined with newlines for the action input).
+are exported (joined with commas for the action input).
 
 ---
 
@@ -5568,7 +5571,7 @@ public readonly exportEnvironmentVariables: ExportEnvironmentVariables;
 Whether to export environment variables from ESC.
 
 Can also be an array of mapping strings to explicitly control which variables
-are exported (joined with newlines for the action input).
+are exported (joined with commas for the action input).
 
 ---
 
@@ -5646,7 +5649,7 @@ public readonly exportEnvironmentVariables: ExportEnvironmentVariables;
 Whether to export environment variables from ESC.
 
 Can also be an array of mapping strings to explicitly control which variables
-are exported (joined with newlines for the action input).
+are exported (joined with commas for the action input).
 
 ---
 
@@ -11506,7 +11509,8 @@ ExportEnvironmentVariables.fromMapping(mapping: string[])
 Provide explicit mappings to export.
 
 Each entry should follow the ESC action mapping format, for example
-`GITHUB_TOKEN=PULUMI_BOT_TOKEN` or `AWS_ACCESS_KEY_ID`.
+`GITHUB_TOKEN=PULUMI_BOT_TOKEN` or `AWS_ACCESS_KEY_ID`. The values are
+rendered as a comma-delimited string for the ESC action input.
 
 ###### `mapping`<sup>Required</sup> <a name="mapping" id="@hallcor/pulumi-projen-project-types.ExportEnvironmentVariables.fromMapping.parameter.mapping"></a>
 

--- a/API.md
+++ b/API.md
@@ -4817,8 +4817,8 @@ public readonly privateKeySecret: string;
 
 The secret containing the GitHub App private key.
 
-Escaped newlines (\\n) will be automatically replaced with actual newlines.
 When `pulumiEscSetup` is provided, this value is used as the ESC output key.
+Escaped newlines (\\n) will be automatically replaced with actual newlines.
 
 ---
 
@@ -4864,7 +4864,7 @@ const githubCredentialsPersonalAccessTokenOptions: GithubCredentialsPersonalAcce
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsPersonalAccessTokenOptions.property.pulumiEscSetup">pulumiEscSetup</a></code> | <code><a href="#@hallcor/pulumi-projen-project-types.PulumiEscSetup">PulumiEscSetup</a></code> | Optionally include setup steps to inject environment variables from Pulumi ESC. |
+| <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsPersonalAccessTokenOptions.property.pulumiEscSetup">pulumiEscSetup</a></code> | <code><a href="#@hallcor/pulumi-projen-project-types.PulumiEscSetup">PulumiEscSetup</a></code> | Optionally include setup steps and resolve app credentials from Pulumi ESC outputs. |
 | <code><a href="#@hallcor/pulumi-projen-project-types.GithubCredentialsPersonalAccessTokenOptions.property.secret">secret</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -4878,7 +4878,7 @@ public readonly pulumiEscSetup: PulumiEscSetup;
 - *Type:* <a href="#@hallcor/pulumi-projen-project-types.PulumiEscSetup">PulumiEscSetup</a>
 - *Default:* do not include pulumi esc setup
 
-Optionally include setup steps to inject environment variables from Pulumi ESC.
+Optionally include setup steps and resolve app credentials from Pulumi ESC outputs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -288,22 +288,16 @@ new TypeScriptComponent({
 new TypeScriptComponent({
   ...,
   projenCredentials: GithubCredentials.fromApp({
+    clientIdSecret: 'PULUMI_PROVIDER_AUTOMATION_APP_ID',
+    privateKeySecret: 'PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY',
     pulumiEscSetup: PulumiEscSetup.fromOidcAuth({
       environment: 'imports/github-secrets',
       organization: 'pulumi',
       requestedToken: PulumiToken.fromOrgToken(),
-      exportEnvironmentVariables: ExportEnvironmentVariables.fromMapping([
-        'PROJEN_APP_CLIENT_ID=PULUMI_PROVIDER_AUTOMATION_APP_ID',
-        'PROJEN_APP_PRIVATE_KEY=PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY',
-      ]),
     }),
   }),
 });
 ```
-
-This flow still configures `exportEnvironmentVariables` on the ESC action so the
-mapped keys are emitted, but `GithubCredentials.fromApp(...)` consumes the ESC
-step outputs rather than `${{ env.* }}` references.
 
 When `pulumiEscSetup` is supplied to `GithubCredentials.fromApp(...)`, the generated
 GitHub App token step reads `app-id` and `private-key` from ESC step outputs using

--- a/README.md
+++ b/README.md
@@ -278,14 +278,38 @@ new TypeScriptComponent({
   ...,
   projenCredentials: GithubCredentials.fromApp({
     privateKeySecret: 'MY_GITHUB_APP_PRIVATE_KEY',
-    appIdSecret: 'MY_GITHUB_APP_ID',
+    clientIdSecret: 'MY_GITHUB_APP_ID',
   }),
 });
 ```
 
+**From a GitHub app via Pulumi ESC**
+```ts
+new TypeScriptComponent({
+  ...,
+  projenCredentials: GithubCredentials.fromApp({
+    pulumiEscSetup: PulumiEscSetup.fromOidcAuth({
+      environment: 'imports/github-secrets',
+      organization: 'pulumi',
+      requestedToken: PulumiToken.fromOrgToken(),
+      exportEnvironmentVariables: ExportEnvironmentVariables.fromMapping([
+        'PROJEN_APP_CLIENT_ID=PULUMI_PROVIDER_AUTOMATION_APP_ID',
+        'PROJEN_APP_PRIVATE_KEY=PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY',
+      ]),
+    }),
+  }),
+});
+```
+
+When `pulumiEscSetup` is supplied to `GithubCredentials.fromApp(...)`, the generated
+GitHub App token step reads `app-id` and `private-key` from ESC step outputs using
+the `clientIdSecret` and `privateKeySecret` names as output keys.
+
 ## Pulumi ESC setup for GitHub Actions
 
 Use the `PulumiEscSetup` helper to add the [`pulumi/esc-action`](https://github.com/pulumi/esc-action) to generated workflows and control which secrets are exported. The helper keeps the step id stable (`esc`) so you can safely reference the action outputs from later steps.
+
+Mapped `exportEnvironmentVariables` values are passed to the ESC action as a comma-delimited string.
 
 ### Option-to-input mapping
 

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ new TypeScriptComponent({
 new TypeScriptComponent({
   ...,
   projenCredentials: GithubCredentials.fromApp({
-    clientIdSecret: 'PULUMI_PROVIDER_AUTOMATION_APP_ID',
-    privateKeySecret: 'PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY',
+    clientIdSecret: 'MY_GITHUB_APP_ID',
+    privateKeySecret: 'MY_GITHUB_APP_PRIVATE_KEY',
     pulumiEscSetup: PulumiEscSetup.fromOidcAuth({
       environment: 'imports/github-secrets',
       organization: 'pulumi',

--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ new TypeScriptComponent({
 });
 ```
 
+This flow still configures `exportEnvironmentVariables` on the ESC action so the
+mapped keys are emitted, but `GithubCredentials.fromApp(...)` consumes the ESC
+step outputs rather than `${{ env.* }}` references.
+
 When `pulumiEscSetup` is supplied to `GithubCredentials.fromApp(...)`, the generated
 GitHub App token step reads `app-id` and `private-key` from ESC step outputs using
 the `clientIdSecret` and `privateKeySecret` names as output keys.

--- a/projenrc/structs/github.ts
+++ b/projenrc/structs/github.ts
@@ -31,7 +31,7 @@ export function githubStructs(project: TypeScriptProject) {
     optional: true,
     docs: {
       summary:
-        'Optionally include setup steps to inject environment variables from Pulumi ESC',
+        'Optionally include setup steps and resolve app credentials from Pulumi ESC outputs',
       default: 'do not include pulumi esc setup',
     },
   };
@@ -43,6 +43,9 @@ export function githubStructs(project: TypeScriptProject) {
     .add(pulumiEscSetup)
     .update('privateKeySecret', {
       docs: {
+        summary:
+          'The secret containing the GitHub App private key.\n' +
+          'When `pulumiEscSetup` is provided, this value is used as the ESC output key.',
         default: 'PROJEN_APP_PRIVATE_KEY',
       },
     })
@@ -52,7 +55,9 @@ export function githubStructs(project: TypeScriptProject) {
       optional: true,
       docs: {
         default: 'PROJEN_APP_CLIENT_ID',
-        summary: 'The name of the secret that contains the app client id',
+        summary:
+          'The name of the secret that contains the app client id.\n' +
+          'When `pulumiEscSetup` is provided, this value is used as the ESC output key.',
       },
     });
 

--- a/src/github-credentials.ts
+++ b/src/github-credentials.ts
@@ -52,7 +52,8 @@ export class GithubCredentials {
       options.privateKeySecret ?? 'PROJEN_APP_PRIVATE_KEY';
 
     const setupSteps: JobStep[] = [];
-    const prefix = options.pulumiEscSetup ? 'env' : 'secrets';
+    let clientIdRef = `\${{ secrets.${clientIdSecret} }}`;
+    let privateKeyRef = `\${{ secrets.${privateKeySecret} }}`;
     if (options.pulumiEscSetup) {
       if (options.pulumiEscSetup.keys) {
         if (!options.pulumiEscSetup.keys.includes(clientIdSecret)) {
@@ -67,6 +68,8 @@ export class GithubCredentials {
         }
       }
       setupSteps.push(...options.pulumiEscSetup.setupSteps);
+      clientIdRef = options.pulumiEscSetup.output(clientIdSecret);
+      privateKeyRef = options.pulumiEscSetup.output(privateKeySecret);
     }
 
     return new GithubCredentials({
@@ -78,8 +81,8 @@ export class GithubCredentials {
           id: 'generate_token',
           uses: 'actions/create-github-app-token@v1',
           with: {
-            'app-id': `\${{ ${prefix}.${clientIdSecret} }}`, // can be client-id
-            'private-key': `\${{ ${prefix}.${privateKeySecret} }}`,
+            'app-id': clientIdRef, // can be client-id
+            'private-key': privateKeyRef,
           },
         },
       ],

--- a/src/pulumi-esc-setup.ts
+++ b/src/pulumi-esc-setup.ts
@@ -27,7 +27,8 @@ export class ExportEnvironmentVariables {
    * Provide explicit mappings to export.
    *
    * Each entry should follow the ESC action mapping format, for example
-   * `GITHUB_TOKEN=PULUMI_BOT_TOKEN` or `AWS_ACCESS_KEY_ID`.
+   * `GITHUB_TOKEN=PULUMI_BOT_TOKEN` or `AWS_ACCESS_KEY_ID`. The values are
+   * rendered as a comma-delimited string for the ESC action input.
    */
   public static fromMapping(mapping: string[]): ExportEnvironmentVariables {
     return new ExportEnvironmentVariables(mapping);
@@ -38,7 +39,7 @@ export class ExportEnvironmentVariables {
    */
   public _render(): boolean | string {
     if (Array.isArray(this.value)) {
-      return this.value.join('\n');
+      return this.value.join(',');
     }
     return this.value;
   }
@@ -69,7 +70,7 @@ export interface PulumiEscActionOptions {
    * Whether to export environment variables from ESC.
    *
    * Can also be an array of mapping strings to explicitly control which variables
-   * are exported (joined with newlines for the action input).
+   * are exported (joined with commas for the action input).
    *
    * @default ExportEnvironmentVariables.disabled()
    */

--- a/src/structs/github-options/access-token-options.ts
+++ b/src/structs/github-options/access-token-options.ts
@@ -10,7 +10,7 @@ export interface GithubCredentialsPersonalAccessTokenOptions {
    */
   readonly secret?: string;
   /**
-   * Optionally include setup steps to inject environment variables from Pulumi ESC
+   * Optionally include setup steps and resolve app credentials from Pulumi ESC outputs
    * @default do not include pulumi esc setup
    */
   readonly pulumiEscSetup?: PulumiEscSetup;

--- a/src/structs/github-options/app-options.ts
+++ b/src/structs/github-options/app-options.ts
@@ -15,8 +15,8 @@ If owner and repositories are empty, access will be scoped to only the current r
   readonly repositories?: Array<string>;
   /**
    * The secret containing the GitHub App private key.
+When `pulumiEscSetup` is provided, this value is used as the ESC output key.
    * Escaped newlines (\\n) will be automatically replaced with actual newlines.
-   * When `pulumiEscSetup` is provided, this value is used as the ESC output key.
    * @default PROJEN_APP_PRIVATE_KEY
    * @stability experimental
    */
@@ -40,7 +40,7 @@ If owner and repositories are empty, access will be scoped to only the current r
   readonly pulumiEscSetup?: PulumiEscSetup;
   /**
    * The name of the secret that contains the app client id.
-   * When `pulumiEscSetup` is provided, this value is used as the ESC output key.
+When `pulumiEscSetup` is provided, this value is used as the ESC output key.
    * @default PROJEN_APP_CLIENT_ID
    */
   readonly clientIdSecret?: string;

--- a/src/structs/github-options/app-options.ts
+++ b/src/structs/github-options/app-options.ts
@@ -16,6 +16,7 @@ If owner and repositories are empty, access will be scoped to only the current r
   /**
    * The secret containing the GitHub App private key.
    * Escaped newlines (\\n) will be automatically replaced with actual newlines.
+   * When `pulumiEscSetup` is provided, this value is used as the ESC output key.
    * @default PROJEN_APP_PRIVATE_KEY
    * @stability experimental
    */
@@ -33,12 +34,13 @@ If owner and repositories are empty, access will be scoped to only the current r
    */
   readonly owner?: string;
   /**
-   * Optionally include setup steps to inject environment variables from Pulumi ESC
+   * Optionally include setup steps and resolve app credentials from Pulumi ESC outputs
    * @default do not include pulumi esc setup
    */
   readonly pulumiEscSetup?: PulumiEscSetup;
   /**
-   * The name of the secret that contains the app client id
+   * The name of the secret that contains the app client id.
+   * When `pulumiEscSetup` is provided, this value is used as the ESC output key.
    * @default PROJEN_APP_CLIENT_ID
    */
   readonly clientIdSecret?: string;

--- a/test/github-credentials.test.ts
+++ b/test/github-credentials.test.ts
@@ -1,0 +1,43 @@
+import {
+  GithubCredentials,
+  PulumiEscSetup,
+  PulumiToken,
+} from '../src';
+
+describe('GithubCredentials', () => {
+  test('fromApp uses ESC step outputs when pulumiEscSetup is provided', () => {
+    const esc = PulumiEscSetup.fromOidcAuth({
+      environment: 'imports/github-secrets',
+      organization: 'pulumi',
+      requestedToken: PulumiToken.fromOrgToken(),
+    });
+
+    const credentials = GithubCredentials.fromApp({
+      pulumiEscSetup: esc,
+    });
+
+    expect(credentials.setupSteps).toHaveLength(2);
+    expect(credentials.setupSteps[1]).toMatchObject({
+      id: 'generate_token',
+      uses: 'actions/create-github-app-token@v1',
+      with: {
+        'app-id': '${{ steps.esc.outputs.PROJEN_APP_CLIENT_ID }}',
+        'private-key': '${{ steps.esc.outputs.PROJEN_APP_PRIVATE_KEY }}',
+      },
+    });
+  });
+
+  test('fromApp still uses repository secrets when pulumiEscSetup is not provided', () => {
+    const credentials = GithubCredentials.fromApp();
+
+    expect(credentials.setupSteps).toHaveLength(1);
+    expect(credentials.setupSteps[0]).toMatchObject({
+      id: 'generate_token',
+      uses: 'actions/create-github-app-token@v1',
+      with: {
+        'app-id': '${{ secrets.PROJEN_APP_CLIENT_ID }}',
+        'private-key': '${{ secrets.PROJEN_APP_PRIVATE_KEY }}',
+      },
+    });
+  });
+});

--- a/test/pulumi-esc-setup.test.ts
+++ b/test/pulumi-esc-setup.test.ts
@@ -1,0 +1,46 @@
+import {
+  ExportEnvironmentVariables,
+  PulumiEscSetup,
+} from '../src/pulumi-esc-setup';
+
+describe('PulumiEscSetup', () => {
+  test('renders mapped exports as a comma-delimited esc-action input for PAT auth', () => {
+    const esc = PulumiEscSetup.fromPersonalAccessToken({
+      environment: 'acme/catalog/prod',
+      exportEnvironmentVariables: ExportEnvironmentVariables.fromMapping([
+        'AWS_ACCESS_KEY_ID',
+        'CD_TOKEN=DEPLOY_TOKEN',
+        '*',
+      ]),
+    });
+
+    expect(esc.setupSteps).toHaveLength(1);
+    expect(esc.setupSteps[0]?.with).toMatchObject({
+      'export-environment-variables':
+        'AWS_ACCESS_KEY_ID,CD_TOKEN=DEPLOY_TOKEN,*',
+      environment: 'acme/catalog/prod',
+      keys: undefined,
+    });
+  });
+
+  test('renders mapped exports as a comma-delimited esc-action input for OIDC auth', () => {
+    const esc = PulumiEscSetup.fromOidcAuth({
+      environment: 'acme/catalog/prod',
+      organization: 'acme',
+      exportEnvironmentVariables: ExportEnvironmentVariables.fromMapping([
+        'AWS_ACCESS_KEY_ID',
+        'CD_TOKEN=DEPLOY_TOKEN',
+      ]),
+    });
+
+    expect(esc.setupSteps).toHaveLength(1);
+    expect(esc.setupSteps[0]?.with).toMatchObject({
+      'export-environment-variables':
+        'AWS_ACCESS_KEY_ID,CD_TOKEN=DEPLOY_TOKEN',
+      environment: 'acme/catalog/prod',
+      keys: undefined,
+      'oidc-auth': true,
+      'oidc-organization': 'acme',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- render `ExportEnvironmentVariables.fromMapping(...)` as a comma-delimited ESC action input
- update `GithubCredentials.fromApp(...)` to consume ESC step outputs instead of env vars when `pulumiEscSetup` is configured
- document the ESC-backed GitHub App flow in the README and refresh API docs

## Testing
- `npx projen test`